### PR TITLE
Implement authentication using kubeconfig.

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -27,6 +27,7 @@ var (
 
 type Config struct {
 	Host           string
+	Kubeconfig     string
 	TemplatePath   string
 	TemplateString string
 	Output         string

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -7,16 +7,24 @@ import (
 	kselector "k8s.io/client-go/pkg/fields"
 	krest "k8s.io/client-go/rest"
 	kcache "k8s.io/client-go/tools/cache"
+	kcmd "k8s.io/client-go/tools/clientcmd"
 )
 
 // Initializes a new Kubernetes API Client
-// TODO: Authentication
-// TODO: look inte pkg/client/clientcmd for loading config
-// TODO: standard environment variables?
 func newKubeClient(c Config) (*kclient.Clientset, error) {
-	config := &krest.Config{
-		Host:          c.Host,
-		ContentConfig: krest.ContentConfig{GroupVersion: &kapi.SchemeGroupVersion},
+	var config *krest.Config
+	var err error
+	if c.Host == "" {
+		// use the current context in kubeconfig
+		config, err = kcmd.BuildConfigFromFlags("", c.Kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		config = &krest.Config{
+			Host:          c.Host,
+			ContentConfig: krest.ContentConfig{GroupVersion: &kapi.SchemeGroupVersion},
+		}
 	}
 	return kclient.NewForConfig(config)
 }


### PR DESCRIPTION
Implement authentication using __kubeconfig__ flag. If __host__ is not specified - uses __kubeconfig__ flag - defaults to _$HOME/.kube/config_.
Host default value is set to empty string.