### PR TITLE
Add Windows support

### DIFF
--- a/cmd/kube-gen/main.go
+++ b/cmd/kube-gen/main.go
@@ -72,7 +72,9 @@ Arguments:
 
 func parseFlags() {
 	flags.StringVar(&host, "host", "", "If not set will use kubeconfig. If using proxy - set it to http://localhost:8001")
-	if home := homeDir(); home != "" {
+	if kubeconfigEnv := os.Getenv("KUBECONFIG"); kubeconfigEnv != "" {
+		flags.StringVar(&kubeconfig, "kubeconfig", kubeconfigEnv, "(optional) environment variable for the kubeconfig file")
+	} else if home := homeDir(); home != "" {
 		flags.StringVar(&kubeconfig, "kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		flags.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")

--- a/template_funcs.go
+++ b/template_funcs.go
@@ -145,7 +145,7 @@ func execShell(cs string) *ShellResult {
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
-	cmd := exec.Command("/bin/sh", "-c", cs)
+	cmd := exec.Command(SHELL_EXE, SHELL_ARG, cs)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()

--- a/util_unix.go
+++ b/util_unix.go
@@ -1,0 +1,28 @@
+// +build !windows
+
+package kubegen
+
+import (
+    "os"
+    "fmt"
+)
+
+const SHELL_EXE = "/bin/sh"
+const SHELL_ARG = "-c"
+
+func setFileModeAndOwnership(f *os.File, fi os.FileInfo) error {
+    if err := f.Chmod(fi.Mode()); err != nil {
+        return fmt.Errorf("error setting file permissions: %v", err)
+    }
+    if err := f.Chown(int(fi.Sys().(*syscall.Stat_t).Uid), int(fi.Sys().(*syscall.Stat_t).Gid)); err != nil {
+        return fmt.Errorf("error changing file owner: %v", err)
+    }
+    return nil
+}
+
+func moveFile(src string, dest string) error {
+    if err = os.Rename(src, dest); err != nil {
+        return fmt.Errorf("error creating output file: %v", err)
+    }
+    return nil
+}

--- a/util_unix.go
+++ b/util_unix.go
@@ -3,26 +3,27 @@
 package kubegen
 
 import (
-    "os"
-    "fmt"
+	"fmt"
+	"os"
+	"syscall"
 )
 
 const SHELL_EXE = "/bin/sh"
 const SHELL_ARG = "-c"
 
 func setFileModeAndOwnership(f *os.File, fi os.FileInfo) error {
-    if err := f.Chmod(fi.Mode()); err != nil {
-        return fmt.Errorf("error setting file permissions: %v", err)
-    }
-    if err := f.Chown(int(fi.Sys().(*syscall.Stat_t).Uid), int(fi.Sys().(*syscall.Stat_t).Gid)); err != nil {
-        return fmt.Errorf("error changing file owner: %v", err)
-    }
-    return nil
+	if err := f.Chmod(fi.Mode()); err != nil {
+		return fmt.Errorf("error setting file permissions: %v", err)
+	}
+	if err := f.Chown(int(fi.Sys().(*syscall.Stat_t).Uid), int(fi.Sys().(*syscall.Stat_t).Gid)); err != nil {
+		return fmt.Errorf("error changing file owner: %v", err)
+	}
+	return nil
 }
 
 func moveFile(src string, dest string) error {
-    if err = os.Rename(src, dest); err != nil {
-        return fmt.Errorf("error creating output file: %v", err)
-    }
-    return nil
+	if err := os.Rename(src, dest); err != nil {
+		return fmt.Errorf("error creating output file: %v", err)
+	}
+	return nil
 }

--- a/util_win.go
+++ b/util_win.go
@@ -3,23 +3,23 @@
 package kubegen
 
 import (
-    "fmt"
-    "os"
-    "os/exec"
+	"fmt"
+	"os"
+	"os/exec"
 )
 
 const SHELL_EXE = "cmd"
 const SHELL_ARG = "/c"
 
 func setFileModeAndOwnership(f *os.File, fi os.FileInfo) error {
-    return nil
+	return nil
 }
 
 func moveFile(src string, dest string) error {
-    moveCmd := "move " + src + " " + dest
-    cmd := exec.Command(SHELL_EXE, SHELL_ARG, moveCmd)
-    if err := cmd.Run(); err != nil {
-        return fmt.Errorf("error creating output file: %v", err)
-    }
-    return nil
+	moveCmd := "move " + src + " " + dest
+	cmd := exec.Command(SHELL_EXE, SHELL_ARG, moveCmd)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error creating output file: %v", err)
+	}
+	return nil
 }

--- a/util_win.go
+++ b/util_win.go
@@ -1,0 +1,25 @@
+// +build windows
+
+package kubegen
+
+import (
+    "fmt"
+    "os"
+    "os/exec"
+)
+
+const SHELL_EXE = "cmd"
+const SHELL_ARG = "/c"
+
+func setFileModeAndOwnership(f *os.File, fi os.FileInfo) error {
+    return nil
+}
+
+func moveFile(src string, dest string) error {
+    moveCmd := "move " + src + " " + dest
+    cmd := exec.Command(SHELL_EXE, SHELL_ARG, moveCmd)
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("error creating output file: %v", err)
+    }
+    return nil
+}


### PR DESCRIPTION
Add Windows support by moving platform specific methods into 2 separate utility files (_unix and _win), so that they will be compiled based on the os.
Also, improve authentication. User may specify KUBECONFIG env var since it may not always be in defined in $HOME/.kube/config. If KUBECONFIG env var is not specified, use host. If host is not specified, then only default to $HOME/.kube/config.