### PR TITLE
Added -node-envvar to watch pods on a specific node

### DIFF
--- a/cmd/kube-gen/main.go
+++ b/cmd/kube-gen/main.go
@@ -32,6 +32,7 @@ var (
 	interval     int
 	quiet        bool
 	showVersion  bool
+	nodeEnvvar   string
 
 	// build info
 	version   string
@@ -83,6 +84,8 @@ func parseFlags() {
 		"If not specified, all types will be returned")
 	flags.BoolVar(&showVersion, "version", false, "display version information")
 	flags.BoolVar(&watch, "watch", false, "watch for new events")
+	flags.StringVar(&nodeEnvvar, "node-envvar", "", "only watch pods in the node specified by this environment variable. "+
+		"If not specified, watch pods in the whole cluster")
 	flags.StringVar(&preCmd, "pre-cmd", "", "command to run before template generation")
 	flags.StringVar(&postCmd, "post-cmd", "", "command to run after template generation in complete")
 	flags.BoolVar(&logCmdOutput, "log-cmd", true, "log the output of the pre/post commands")
@@ -131,6 +134,17 @@ func parseWait(w string) (min time.Duration, max time.Duration, err error) {
 	return
 }
 
+func getNode(env string) (node string, err error) {
+	if env == "" {
+		return "", nil
+	}
+	if node, ok := os.LookupEnv(env); ok {
+		return node, nil
+	}
+	err = fmt.Errorf("envvar %s not found", env)
+	return
+}
+
 func tmplFromStdin() ([]byte, error) {
 	return ioutil.ReadAll(os.Stdin)
 }
@@ -150,6 +164,11 @@ func main() {
 	if narg := flags.NArg(); narg < 1 || narg > 2 {
 		flags.Usage()
 		os.Exit(1)
+	}
+
+	node, err := getNode(nodeEnvvar)
+	if err != nil {
+		log.Fatalf("error getting node: %v", err)
 	}
 
 	minWait, maxWait, err := parseWait(wait)
@@ -184,6 +203,7 @@ func main() {
 		MinWait:        minWait,
 		MaxWait:        maxWait,
 		Interval:       interval,
+		Node:           node,
 	}
 
 	gen, err := kubegen.NewGenerator(conf)


### PR DESCRIPTION
When deployed as a daemonset, any pod event that happens will trigger all the kube-gen instances to load all pods. This becomes very expensive in a large cluster.  The -node-envvar argument allows kube-gen to watch and load pods only on a specific/local node defined by this environment variable.

NOTES:
- We can't use the node name directly in the cli argument because at the deployment time, we don't know on which node kube-gen will land. So instead, we use environment variable that can be injected using kubernetes downward API.