### PR TITLE
[feat] Use In Cluster Config to remove dependency on a kubectl container running kubectl proxy when running pod inside a K8s Cluster

### DIFF
--- a/cmd/kube-gen/main.go
+++ b/cmd/kube-gen/main.go
@@ -32,6 +32,7 @@ var (
 	interval     int
 	quiet        bool
 	showVersion  bool
+	inCluster    bool
 
 	// build info
 	version   string
@@ -91,7 +92,7 @@ func parseFlags() {
 		"E.g.: 500ms:5s")
 	flags.IntVar(&interval, "interval", 0, "")
 	flags.BoolVar(&quiet, "quiet", false, "when set to true, nothing is logged")
-
+	flags.BoolVar(&inCluster, "in-cluster", false, "use inClusterConfig for k8s config")
 	flags.Usage = usage
 	flags.Parse(os.Args[1:])
 }
@@ -171,19 +172,20 @@ func main() {
 	}
 
 	conf := kubegen.Config{
-		Host:           host,
-		Kubeconfig:     kubeconfig,
-		TemplateString: tmplStr,
-		TemplatePath:   flags.Arg(0),
-		Output:         flags.Arg(1),
-		Overwrite:      overwrite,
-		Watch:          watch,
-		PreCmd:         preCmd,
-		PostCmd:        postCmd,
-		ResourceTypes:  types,
-		MinWait:        minWait,
-		MaxWait:        maxWait,
-		Interval:       interval,
+		Host:               host,
+		Kubeconfig:         kubeconfig,
+		TemplateString:     tmplStr,
+		TemplatePath:       flags.Arg(0),
+		Output:             flags.Arg(1),
+		Overwrite:          overwrite,
+		Watch:              watch,
+		PreCmd:             preCmd,
+		PostCmd:            postCmd,
+		ResourceTypes:      types,
+		MinWait:            minWait,
+		MaxWait:            maxWait,
+		Interval:           interval,
+		UseInClusterConfig: inCluster,
 	}
 
 	gen, err := kubegen.NewGenerator(conf)

--- a/generator.go
+++ b/generator.go
@@ -26,20 +26,21 @@ var (
 )
 
 type Config struct {
-	Host           string
-	Kubeconfig     string
-	TemplatePath   string
-	TemplateString string
-	Output         string
-	Overwrite      bool
-	Watch          bool
-	PreCmd         string
-	PostCmd        string
-	LogCmdOutput   bool
-	Interval       int
-	MinWait        time.Duration
-	MaxWait        time.Duration
-	ResourceTypes  []string
+	Host               string
+	Kubeconfig         string
+	TemplatePath       string
+	TemplateString     string
+	Output             string
+	Overwrite          bool
+	Watch              bool
+	PreCmd             string
+	PostCmd            string
+	LogCmdOutput       bool
+	Interval           int
+	MinWait            time.Duration
+	MaxWait            time.Duration
+	ResourceTypes      []string
+	UseInClusterConfig bool
 }
 
 type Generator interface {

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -14,9 +14,14 @@ import (
 func newKubeClient(c Config) (*kclient.Clientset, error) {
 	var config *krest.Config
 	var err error
-	if c.Host == "" {
+	if c.Host == "" && !c.UseInClusterConfig {
 		// use the current context in kubeconfig
 		config, err = kcmd.BuildConfigFromFlags("", c.Kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	} else if c.UseInClusterConfig {
+		config, err = krest.InClusterConfig()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When running inside a pod , with service account tokem kubenetes clients can use [InClusterConfig](https://github.com/kubernetes/client-go/blob/a16e76eb69cc9eea8e9c9124a64e6e58a583dad2/rest/config.go#L512)
```// InClusterConfig returns a config object which uses the service account
// kubernetes gives to pods. It's intended for clients that expect to be
// running inside a pod running on kubernetes. It will return ErrNotInCluster
// if called from a process not running in a kubernetes environment.
```

This obliterates the need to include a kubectl container for running kubectl proxy